### PR TITLE
Add details panel displaying frozen status

### DIFF
--- a/NodePropertyPalette/NodePropertyPaletteViewModel.cs
+++ b/NodePropertyPalette/NodePropertyPaletteViewModel.cs
@@ -125,6 +125,7 @@ namespace NodePropertyPalette
             if (propertyPaletteNode != null)
             {
                 PropertyPaletteNodes.Remove(propertyPaletteNode);
+                propertyPaletteNode.Dispose();
             }
             RaisePropertyChanged(nameof(PropertyPaletteNodesCollection));
         }
@@ -160,6 +161,12 @@ namespace NodePropertyPalette
                 node.NodeExecutionBegin -= OnNodeExecutionBegin;
                 node.NodeExecutionEnd -= OnNodeExecutionEnd;
             }
+
+            foreach (var node in PropertyPaletteNodes)
+            {
+                node.Dispose();
+            }
+            PropertyPaletteNodes.Clear();
         }
 
         /// <summary>
@@ -173,7 +180,7 @@ namespace NodePropertyPalette
             workspace.NodeRemoved += CurrentWorkspaceModel_NodeRemoved;
             workspace.EvaluationStarted += CurrentWorkspaceModel_EvaluationStarted;
             workspace.EvaluationCompleted += CurrentWorkspaceModel_EvaluationCompleted;
-            PropertyPaletteNodes.Clear();
+            
             foreach (var node in workspace.Nodes)
             {
                 var profiledNode = new PropertyPaletteNodeViewModel(node);

--- a/NodePropertyPalette/NodePropertyPaletteWindow.xaml
+++ b/NodePropertyPalette/NodePropertyPaletteWindow.xaml
@@ -176,6 +176,14 @@
                     </DataGridTextColumn>
 
                 </DataGrid.Columns>
+                <!-- Expanded Details -->
+                <DataGrid.RowDetailsTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                            <CheckBox IsChecked="{Binding IsFrozen, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Content="Frozen"/>
+                        </StackPanel>
+                    </DataTemplate>
+                </DataGrid.RowDetailsTemplate>
             </DataGrid>
         </StackPanel>
     </Grid>

--- a/NodePropertyPalette/PropertyPaletteNodeViewModel.cs
+++ b/NodePropertyPalette/PropertyPaletteNodeViewModel.cs
@@ -1,9 +1,15 @@
 ﻿using Dynamo.Core;
 using Dynamo.Graph.Nodes;
+using System;
+using System.ComponentModel;
+using System.Linq;
+
 namespace NodePropertyPalette
 {
-    public class PropertyPaletteNodeViewModel : NotificationObject
+    public class PropertyPaletteNodeViewModel : NotificationObject, IDisposable
     {
+        private readonly string[] BoundProperties = new string[] { "IsFrozen" };
+
         #region Properties
         /// <summary>
         /// The name of this PropertyPalette Node.
@@ -28,6 +34,18 @@ namespace NodePropertyPalette
             }
         }
 
+        public bool IsFrozen
+        {
+            get
+            {
+                return NodeModel.IsFrozen;
+            }
+            set
+            {
+                NodeModel.IsFrozen = value;
+            }
+        }
+
         internal NodeModel NodeModel { get; set; }
 
         #endregion
@@ -39,6 +57,30 @@ namespace NodePropertyPalette
         public PropertyPaletteNodeViewModel(NodeModel node)
         {
             NodeModel = node;
+            SubscribeToUpdateEvents();
+        }
+
+        public void Dispose()
+        {
+            UnsubscribeFromUpdateEvents();
+        }
+
+        private void UnsubscribeFromUpdateEvents()
+        {
+            NodeModel.PropertyChanged -= Node_PropertyChanged;
+        }
+
+        private void SubscribeToUpdateEvents()
+        {
+            NodeModel.PropertyChanged += Node_PropertyChanged;
+        }
+
+        private void Node_PropertyChanged(object sender, PropertyChangedEventArgs e)
+        {
+            if (BoundProperties.Contains(e.PropertyName))
+            {
+                RaisePropertyChanged(e.PropertyName);
+            }
         }
     }
 }


### PR DESCRIPTION
Added a row details panel to display information about a single node.
Currently, it displays whether the node is frozen or not, and allows
two way binding with the workspace.

Please review @QilongTang 
