### PR TITLE
Change selection mode in data grid

### DIFF
--- a/NodePropertyPalette/NodePropertyPaletteWindow.xaml
+++ b/NodePropertyPalette/NodePropertyPaletteWindow.xaml
@@ -39,6 +39,8 @@
                 <Setter Property="Background" Value="#333333"/>
                 <Setter Property="BorderThickness" Value="0.45" />
                 <Setter Property="BorderBrush" Value="#555555"/>
+                <Setter Property="IsSelected" Value="{Binding Selected, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"/>
+                <EventSetter Event="MouseDoubleClick" Handler="DataGridRow_MouseDoubleClick"/>
                 <Style.Triggers>
                     <Trigger Property="IsSelected" Value="True">
                         <Setter Property="Background" Value="#555555" />
@@ -194,6 +196,67 @@
                 <Style.Triggers>
                 </Style.Triggers>
             </Style>
+            
+            <!-- Button style -->
+            <Style x:Key="STextButton" TargetType="{x:Type Button}">
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate>
+                            <Border x:Name="container"
+                            Background="Transparent"
+                            BorderBrush="#3c3c3c"
+                            BorderThickness="1">
+                                <Grid x:Name="inner" Background="#373737" Height="Auto" VerticalAlignment="Top">
+                                    <TextBlock x:Name="text"
+                                       HorizontalAlignment="Center"
+                                       VerticalAlignment="Center"
+                                       Margin="5,2"
+                                       Foreground="#bbbbbb"
+                                       Text="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=Content}"></TextBlock>
+                                </Grid>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="Button.IsMouseOver"
+                                 Value="true">
+                                    <Setter TargetName="container"
+                                    Property="BorderBrush"
+                                    Value="#656565" />
+                                    <Setter TargetName="inner"
+                                    Property="Background"
+                                    Value="#373737" />
+                                </Trigger>
+                                <Trigger Property="Button.IsPressed"
+                                 Value="true">
+                                    <Setter TargetName="container"
+                                    Property="BorderBrush"
+                                    Value="#656565" />
+                                    <Setter TargetName="inner"
+                                    Property="Background"
+                                    Value="#272727" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled"
+                                 Value="true">
+                                    <Setter TargetName="text"
+                                    Property="Foreground"
+                                    Value="#bbbbbb" />
+                                </Trigger>
+                                <Trigger Property="IsEnabled"
+                                 Value="false">
+                                    <Setter TargetName="container"
+                                    Property="BorderBrush"
+                                    Value="Transparent" />
+                                    <Setter TargetName="inner"
+                                    Property="Background"
+                                    Value="#373737" />
+                                    <Setter TargetName="text"
+                                    Property="Foreground"
+                                    Value="#555555" />
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </Grid.Resources>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -215,7 +278,7 @@
             <ComboBox Margin="10,2,0,13" Name="ComboBox1" HorizontalAlignment="Left" VerticalAlignment="Top" Width="Auto" Style="{StaticResource ResourceKey=SComboBox}"
                       ItemsSource="{Binding Source={StaticResource bulkOperationValues}}" SelectedItem="{Binding BulkOperation}">
             </ComboBox>
-            <Button Content="Apply" Click="ApplyButton_Click"/>
+            <Button Content="Apply" Click="ApplyButton_Click" Margin="10,2,0,13" Style="{StaticResource ResourceKey=STextButton}"/>
         </StackPanel>
 
         <StackPanel Grid.Row="1">
@@ -230,14 +293,15 @@
             FontSize="11"
             VerticalAlignment="Center"
             SelectionUnit="FullRow"
-            SelectionMode="Single"
+            SelectionMode="Extended"
             ScrollViewer.CanContentScroll="False" 
             ScrollViewer.HorizontalScrollBarVisibility="Auto"
             ScrollViewer.VerticalScrollBarVisibility="Auto"
             CanUserResizeColumns="True" 
             CanUserSortColumns="True"
             HeadersVisibility="Column"
-            SelectionChanged="NodesTable_SelectionChanged">
+            SelectionChanged="NodesTable_SelectionChanged"
+            RowDetailsVisibilityMode="Collapsed">
 
                 <DataGrid.GroupStyle>
                     <GroupStyle>
@@ -257,25 +321,6 @@
                 </DataGrid.GroupStyle>
 
                 <DataGrid.Columns>
-                    <DataGridTemplateColumn Header="Selected" Width="Auto">
-                        <DataGridTemplateColumn.CellTemplate>
-                            <DataTemplate>
-                                <CheckBox HorizontalAlignment="Center" IsChecked="{Binding Path=Selected, UpdateSourceTrigger=PropertyChanged}" />
-                            </DataTemplate>
-                        </DataGridTemplateColumn.CellTemplate>
-                    </DataGridTemplateColumn>
-                    <!-- TODO: Replace this with check box-->
-                    <!--<DataGridCheckBoxColumn 
-                    Header="Selected" 
-                    Binding="{Binding Path=Selected}"
-                    Width="Auto">-->
-                        <!--<DataGridCheckBoxColumn.ElementStyle>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="VerticalAlignment" Value="Center" />
-                                <Setter Property="Margin" Value="10,0,10,0"/>
-                            </Style>
-                        </DataGridCheckBoxColumn.ElementStyle>-->
-                    <!--</DataGridCheckBoxColumn>-->
 
                     <!-- Node Name -->
                     <DataGridTextColumn 

--- a/NodePropertyPalette/NodePropertyPaletteWindow.xaml.cs
+++ b/NodePropertyPalette/NodePropertyPaletteWindow.xaml.cs
@@ -93,5 +93,11 @@ namespace NodePropertyPalette
         {
             viewModel.ApplyBulkOperation();
         }
+
+        private void DataGridRow_MouseDoubleClick(object sender, System.Windows.Input.MouseButtonEventArgs e)
+        {
+            DataGridRow row = sender as DataGridRow;
+            row.DetailsVisibility = row.DetailsVisibility == Visibility.Collapsed ? Visibility.Visible : Visibility.Collapsed;
+        }
     }
 }


### PR DESCRIPTION
The selected column has been removed. Instead we rely on the DataGrid
multi-selection capabilities. This allows to select multiple items
using keyboard keys Shift and Control, and also avoids the multiple
clicks issue to select a CheckBox.

Showing details for a node is now triggered by double clicking on a
row. This allows to select multiple items without showing the details
for all of them.

Also, the style of the Apply button is improved to look more like
Dynamo.

Please review @QilongTang 

![Screen Shot 2020-03-04 at 11 05 23 AM](https://user-images.githubusercontent.com/10048120/75898487-1e572b80-5e08-11ea-9410-25027bbc5463.png)

Next steps:
- Implement not yet implemented operations: delete, disconnect
- Add extra properties to details row. For instance, allow editing input nodes
- Add context menu to show/hide row details (alternative to double click)