### PR TITLE
[WIP] Add disconnect and delete commands

### DIFF
--- a/NodePropertyPalette/Constants.cs
+++ b/NodePropertyPalette/Constants.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NodePropertyPalette
+{
+    public static class Constants
+    {
+        /// <summary>
+        /// Name of this extension
+        /// </summary>
+        public const string ExtensionName = "NodePropertyPalette";
+        
+        /// <summary>
+        /// The unique ID for the NodePropertyPalette view extension. 
+        /// Used to identify the view extension when sending recordable commands.
+        /// </summary>
+        public const string ExtensionUniqueId = "9B1A1CB9-C448-4B86-809C-2A70FD05DED1";
+    }
+}

--- a/NodePropertyPalette/NodePropertyPalette.csproj
+++ b/NodePropertyPalette/NodePropertyPalette.csproj
@@ -49,6 +49,7 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Constants.cs" />
     <Compile Include="Enums.cs" />
     <Compile Include="PropertyPaletteNodeViewModel.cs" />
     <Compile Include="NodePropertyPaletteViewExtension.cs" />

--- a/NodePropertyPalette/NodePropertyPaletteViewExtension.cs
+++ b/NodePropertyPalette/NodePropertyPaletteViewExtension.cs
@@ -27,7 +27,7 @@ namespace NodePropertyPalette
         public void Loaded(ViewLoadedParams p)
         {
             ViewModel = new NodePropertyPaletteWindowViewModel(p);
-            NodePropertyPaletteView = new NodePropertyPaletteWindow(p, UniqueId, ViewModel)
+            NodePropertyPaletteView = new NodePropertyPaletteWindow(p, ViewModel)
             {
                 // Set the data context for the main grid in the window.
                 NodesTable = { DataContext = ViewModel },
@@ -65,7 +65,7 @@ namespace NodePropertyPalette
         {
             get
             {
-                return "9B1A1CB9-C448-4B86-809C-2A70FD05DED1";
+                return Constants.ExtensionUniqueId;
             }
         }
 
@@ -76,7 +76,7 @@ namespace NodePropertyPalette
         {
             get
             {
-                return "NodePropertyPalette";
+                return Constants.ExtensionName;
             }
         }
     }

--- a/NodePropertyPalette/NodePropertyPaletteViewModel.cs
+++ b/NodePropertyPalette/NodePropertyPaletteViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Data;
 using Dynamo.Core;
 using Dynamo.Graph.Nodes;
 using Dynamo.Graph.Workspaces;
+using Dynamo.Models;
 using Dynamo.Wpf.Extensions;
 
 namespace NodePropertyPalette
@@ -174,7 +175,19 @@ namespace NodePropertyPalette
 
         private void Disconnect(IEnumerable<PropertyPaletteNodeViewModel> selectedNodes)
         {
-            // TODO: Implement this
+            foreach (var node in selectedNodes)
+            {
+                // Materialize the enumeration first to modify it without causing errors
+                foreach (var connector in node.NodeModel.AllConnectors.ToList())
+                {
+                    // This would be the ideal. Unfortunately, the method is not publicly exposed.
+                    //connector.Delete();
+
+                    // This is what can be currently achieved. Connectors are logically deleted but still visible.
+                    connector.Start.Connectors.Remove(connector);
+                    connector.End.Connectors.Remove(connector);
+                }
+            }
         }
 
         private void Unfreeze(IEnumerable<PropertyPaletteNodeViewModel> selectedNodes)
@@ -201,7 +214,13 @@ namespace NodePropertyPalette
 
         private void Delete(IEnumerable<PropertyPaletteNodeViewModel> selectedNodes)
         {
-            // TODO: Implement this
+            // Have to delete individually as multiple deletion only removes the first one
+            // TODO: Investigate why the workspace's NodeRemoved even is not fired.
+            foreach (var node in selectedNodes)
+            {
+                var command = new DynamoModel.DeleteModelCommand(node.NodeModel.GUID);
+                viewLoadedParams.CommandExecutive.ExecuteCommand(command, Constants.ExtensionUniqueId, Constants.ExtensionName);
+            }
         }
 
         #endregion

--- a/NodePropertyPalette/NodePropertyPaletteWindow.xaml.cs
+++ b/NodePropertyPalette/NodePropertyPaletteWindow.xaml.cs
@@ -24,12 +24,6 @@ namespace NodePropertyPalette
         private NodePropertyPaletteWindowViewModel viewModel;
 
         /// <summary>
-        /// The unique ID for the NodePropertyPalette view extension. 
-        /// Used to identify the view extension when sending recordable commands.
-        /// </summary>
-        private string uniqueId;
-
-        /// <summary>
         /// Since there is no API for height offset comparing to
         /// DynamoWindow height. Define it as static for now.
         /// </summary>
@@ -39,7 +33,7 @@ namespace NodePropertyPalette
         /// Create the NodePropertyPalette Window
         /// </summary>
         /// <param name="vlp"></param>
-        public NodePropertyPaletteWindow(ViewLoadedParams vlp, string id, NodePropertyPaletteWindowViewModel vm)
+        public NodePropertyPaletteWindow(ViewLoadedParams vlp, NodePropertyPaletteWindowViewModel vm)
         {
             InitializeComponent();
             viewLoadedParams = vlp;
@@ -49,7 +43,6 @@ namespace NodePropertyPalette
             vlp.DynamoWindow.SizeChanged += DynamoWindow_SizeChanged;
             commandExecutive = vlp.CommandExecutive;
             viewModelCommandExecutive = vlp.ViewModelCommandExecutive;
-            uniqueId = id;
             viewModel = vm;
         }
 
@@ -77,7 +70,7 @@ namespace NodePropertyPalette
             {
                 // Select
                 var command = new DynamoModel.SelectModelCommand(selectedNodes.Select(nm => nm.GUID), ModifierKeys.None);
-                commandExecutive.ExecuteCommand(command, uniqueId, "NodePropertyPalette");
+                commandExecutive.ExecuteCommand(command, Constants.ExtensionUniqueId, Constants.ExtensionName);
 
                 // Focus on selected
                 viewModelCommandExecutive.FindByIdCommand(selectedNodes.First().GUID.ToString());


### PR DESCRIPTION
Implemented disconnect and delete commands but they have serious limitations. This PR is a WIP and it's opened for discussion.


### Disconnect
Removes the logical connection between the nodes but does not make the laces disappear. Ideally should be calling `Delete` on the `ConnectorModel`, but it's not publicly exposed.

Should we have that made public or do it some other way?


### Delete
I find a  way to do this through the command API, but it does not seem to fire the workspace `NodeRemoved` event. As a result, the palette does not get updated and the removed nodes remain listed.

Is there another way to do this that may fire this event?


CC @QilongTang 